### PR TITLE
Update VoilaBot definition

### DIFF
--- a/regexes/bots.yml
+++ b/regexes/bots.yml
@@ -525,6 +525,14 @@
     name: 'Openindex B.V.'
     url: 'http://www.openindex.io'
 
+- regex: 'OrangeBot|VoilaBot'
+  name: 'Orange Bot'
+  category: 'Search bot'
+  url: 'http://lemoteur.orange.fr'
+  producer:
+    name: 'Orange'
+    url: 'http://www.orange.fr'
+
 - regex: 'spbot'
   name: 'OpenLinkProfiler'
   category: 'Crawler'
@@ -788,14 +796,6 @@
   producer:
     name: 'Alentum Software Ltd.'
     url: 'http://www.alentum.com'
-
-- regex: 'VoilaBot'
-  name: 'Voila Bot'
-  category: 'Search bot'
-  url: 'http://www.voila.fr'
-  producer:
-    name: ''
-    url: ''
 
 - regex: 'Jigsaw'
   name: 'W3C CSS Validator'


### PR DESCRIPTION
Orange build a new bot named OrangeBot : http://blog.lemoteur.fr/orangebot/

This bot replace VoilaBot which going to be removed very soon...
